### PR TITLE
Follow best practices for bash

### DIFF
--- a/sbin/grub2-sign
+++ b/sbin/grub2-sign
@@ -6,46 +6,44 @@
 
 
 # Running grub2-verify first to prevent double signing
-echo "Running grub2-verify to check if everything is unsigned..."
+echo "Running grub2-verify to check if everything is unsigned..." >&2
 grub2-verify
-if [ $? -lt 2 ]
-then
-    echo "Run grub2-unsign first."
+if (( $? < 2 )); then
+    echo "Run grub2-unsign first." >&2
     exit 1
 fi
 
 
 # Ask for passphrase
-echo -n "Passphrase: "
-stty -echo
-read pp
-stty echo
-echo -e "\n"
+IFS= read -r -s -p 'Passphrase: ' pp
 
+# build a find command line matching relevant filenames
+name_patterns=(
+	grubenv				# fixed names
+	'*.'{cfg,lst,mod,asc,pf2}	# names with interesting extensions
+	{vmlinuz,initrd}'*'		# names with interesting prefixes
+)
+find_args=( '-false' )
+for pattern in "${name_patterns[@]}"; do find_args+=( '-or' '-name' "$pattern" ); done
 
 # Find GRUB2 datas
-for i in `find /boot -name "*.cfg" -or -name "*.lst" -or \
- -name "*.mod" -or -name "vmlinuz*" -or -name "initrd*" -or \
- -name "grubenv" -or -name "*.asc" -or -name "*.pf2"`;
-do
+while IFS= read -r -d '' i; do
     # Signing
-    echo $pp | gpg --batch --detach-sign --passphrase-fd 0 $i
-    if [ $? -eq 0 ]
-    then
-        echo "$i signed."
+    if gpg --batch --detach-sign --passphrase-fd 0 "$i" <<<"$pp"; then
+        echo "$i signed." >&2
     else
-        echo "ERROR!"
+        echo "ERROR!" >&2
 	break
     fi
-done
-
+done < <(find /boot '(' "${find_args[@]}" ')' '-print0' )
 
 # Shredding passphrase
-echo "Shredding passphrase..."
-for (( i=0; $i<10; i++ ))
-do
-    pp=`cat /dev/urandom | tr -dc 'a-zA-Z0-9-!@#$%^&*()_+~' | fold -w ${#pp} | head -n 1`
-done
+if (( ${#pp} )); then
+    echo "Shredding passphrase..." >&2
+    for (( i=0; i<10; i++ )); do
+	pp=$(LC_ALL=C tr -cd '[:print:]' </dev/urandom | head -c ${#pp})
+    done
+fi
 
-echo "Done!"
+echo "Done!" >&2
 exit 0

--- a/sbin/grub2-unsign
+++ b/sbin/grub2-unsign
@@ -5,13 +5,10 @@
 # Licence: GNU-GPLv3
 
 # Check if something is wrong
-grub2-verify
-if [ $? -eq 1 ]
-then
-    echo -e "grub2-verify has detected a one or more bad signatures.\nPlease check for malicious software before you're unsigning everything!"
+if ! grub2-verify; then
+    printf '%s\n' "grub2-verify has detected a one or more bad signatures." "Please check for malicious software before you're unsigning everything!" >&2
     exit 1
 fi
-
 
 # Then remove the signatures.
 find /boot -name '*.sig' -exec rm -- '{}' +

--- a/sbin/grub2-verify
+++ b/sbin/grub2-verify
@@ -4,62 +4,48 @@
 # Author: Bandie Kojote
 # Licence: GNU-GPLv3
 
-errorcounter=0
-filecounter=0
+red=$(tput setaf 1)
+green=$(tput setaf 2)
+normal=$(tput sgr0)
 
+all_files=( )
+error_files=( )
 
 # Signature check part + error counter + file counter + file list
 
-echo "Checking signatures in /boot..."  
-for i in `find /boot -name "*.sig"` 
-do 
-    gpg --verify-files $i > /dev/null 2>&1
-    if [ $? -ne 0 ]
-    then
-        ((errorcounter++))
-        files[$errorcounter]=$i
+echo "Checking signatures in /boot..." >&2
+while IFS= read -r -d '' i; do
+    if ! gpg --verify-files "$i" >/dev/null 2>&1; then
+        error_files+=( "$i" )
     fi
-    ((filecounter++))
-done
+    all_files+=( "$i" )
+done < <(find /boot -name "*.sig" -print0)
+
 # Nothing to verify? Exit 2.
-if [ $filecounter -eq 0 ]
-then
-    echo "Nothing to verify."
+if (( ${#all_files[@]} == 0 )); then
+    echo "Nothing to verify." >&2
     exit 2
 fi
 
-
-
 # Message
-
-echo -ne "There has been "
-if [ $errorcounter -eq 0 ]
-then
-    echo -ne "\e[1;32mno\e[0m"
+printf '%s' 'Found ' >&2
+if (( ${#error_files} == 0 )); then
+    printf '%s' "$green" "no" "$normal" >&2
 else
-    echo -ne "\e[1;31m$errorcounter\e[0m"
+    printf '%s' "$red" "${#error_files[@]}" "$normal" >&2
 fi
-if [ $errorcounter -eq 1 ]
-then
-    echo " bad signature."
+if (( ${#error_files[@]} == 1 )); then
+    echo " bad signature." >&2
 else
-    echo " bad signatures."
+    echo " bad signatures." >&2
 fi
-
-
 
 # File list and exit codes
-
-if [ $errorcounter -gt 0 ]
-then
-    for(( i=1; i<=${#files[@]}; i++))
-    do
-        echo "BAD signature: ${files[$i]}"
-    done
+if (( ${#error_files[@]} > 0 )); then
+    printf 'BAD signature: %s\n' "${error_files[@]}"
     exit 1
 else
     exit 0
 fi
 
-# WHAT?!
-exit 666 
+exit 99


### PR DESCRIPTION
- Use native bash math where doing so improves readability.
- Avoid illegal exit status codes (666 in impossible scenario).
- Avoid useless use of cat (`cat foo | bar` vs the more efficient `bar <foo`).
- Avoid needless echo pipelines (`echo foo | bar` vs `bar <<<"$foo"`).
- Never use a for loop to iterate over output from `find`; `for` loops depend
  on string-splitting, which is only available with globbing behavior. See
  http://mywiki.wooledge.org/DontReadLinesWithFor
- Use `read -s` to silence feedback rather than playing around with `stty`.
- Use `tput` to retrieve color codes correct for the current terminal rather
  than assuming a terminal compatible with ANSI color codes.
- Use a expression compatible with BSD `tr` in "passphrase-shredding" code.
  (BTW, I very much doubt that this code actually does any good; it's not a
  reasonable expectation that a new string assigned to a variable will actually
  be placed at the same location in memory).
- Implementations of `echo` which do anything other than print `-e` on output
  when `echo -e` is run are nonconformant with the POSIX spec for echo.
  Similarly, `echo -n` behavior is not defined by the standard. Avoid relying
  on either of these. (See http://pubs.opengroup.org/onlinepubs/009604599/utilities/echo.html,
  particularly the APPLICATION USAGE section).
- Always quote expansions to prevent string-splitting and glob-expansion
  (`"$i"`, not `$i`).
- Avoid `some_command; if [ $? -eq 0 ]; then` when `if some_command; then` can
  be used instead.
